### PR TITLE
Add setting items accessKeyId and secretAccessKey that are optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ lambda-config.js
 
 ```node
 module.exports = {
+  accessKeyId: <access key id>,
+  secretAccessKey: <secret access key>,
   region: 'us-east-1',
   handler: 'index.handler',
   role: <role arn>,

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ lambda-config.js
 
 ```node
 module.exports = {
-  accessKeyId: <access key id>,
-  secretAccessKey: <secret access key>,
+  accessKeyId: <access key id>,  // optional
+  secretAccessKey: <secret access key>,  // optional
   region: 'us-east-1',
   handler: 'index.handler',
   role: <role arn>,

--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ exports.deploy = function(codePackage, config, callback, logger, lambda) {
   if(!lambda) {
     lambda = new AWS.Lambda({
       region: config.region,
-      accessKeyId: config.accessKeyId,
-      secretAccessKey: config.secretAccessKey
+      accessKeyId: "accessKeyId" in config ? config.accessKeyId : "",
+      secretAccessKey: "secretAccessKey" in config ? config.secretAccessKey : ""
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,11 @@ exports.deploy = function(codePackage, config, callback, logger, lambda) {
   }
 
   if(!lambda) {
-    lambda = new AWS.Lambda({region: config.region});
+    lambda = new AWS.Lambda({
+      region: config.region,
+      accessKeyId: config.accessKeyId,
+      secretAccessKey: config.secretAccessKey
+    });
   }
 
   var params = {

--- a/test/all.js
+++ b/test/all.js
@@ -19,6 +19,8 @@ describe('node aws lambda module', function() {
   var packageV2 = 'test/helloworld-v2.zip';
   var sampleConfig = {
     region: 'us-west-1',
+    accessKeyId: 'key',
+    secretAccessKey: 'secret',
     handler: 'helloworld.handler',
     role: 'arn:aws:iam:xxxxxx:rol/lambda-exec-role',
     functionName: 'helloworld',


### PR DESCRIPTION
This feature meets a need to deploy lambda on specific AWS accounts.