### PR TITLE
HTTPS_PROXY detect support

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,14 @@ exports.deploy = function(codePackage, config, callback, logger, lambda) {
       var credentials = new AWS.SharedIniFileCredentials({profile: config.profile});
       AWS.config.credentials = credentials;
     }
+    
+    if (process.env.HTTPS_PROXY) {
+      if (!AWS.config.httpOptions)
+        AWS.config.httpOptions = {};
+
+      var HttpsProxyAgent = require('https-proxy-agent');
+      AWS.config.httpOptions.agent = new HttpsProxyAgent(process.env.HTTPS_PROXY);
+    }
 
     lambda = new AWS.Lambda({
       region: config.region,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha test/all.js"
   },
-
   "repository": {
     "type": "git",
     "url": "https://github.com/ThoughtWorksStudios/node-aws-lambda"
@@ -20,12 +19,11 @@
   "bugs": {
     "url": "https://github.com/ThoughtWorksStudios/node-aws-lambda/issues"
   },
-
   "dependencies": {
+    "async": "^1.0.0",
     "aws-sdk": "2.x.x",
-    "async": "^1.0.0"
+    "https-proxy-agent": "^1.0.0"
   },
-
   "devDependencies": {
     "mocha": "^2.2.1",
     "chai": "^2.1.1",


### PR DESCRIPTION
Detect the HTTPS_PROXY environment variable and set the AWS httpOptions.agent property in order to 
deploy Lambda through corporate proxy.