### PR TITLE
Replace usage of undefined `gutil.log` by `logger`

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ exports.deploy = function(codePackage, config, callback, logger, lambda) {
         if (err) {
           var warning = 'Package upload failed. '
           warning += 'Check your iam:PassRole permissions.'
-          gutil.log(warning);
+          logger(warning);
           callback(err)
         } else {
           lambda.updateFunctionConfiguration(params, function(err, data) {


### PR DESCRIPTION
Probably forgotten during a refactoring...