### PR TITLE
Adds the ability to use credentials from sts assumeRole

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ lambda-config.js
 module.exports = {
   accessKeyId: <access key id>,  // optional
   secretAccessKey: <secret access key>,  // optional
+  sessionToken: <sessionToken for assuming roles>,  // optional
   profile: <shared credentials profile name>, // optional for loading AWS credientail from custom profile
   region: 'us-east-1',
   handler: 'index.handler',

--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ exports.deploy = function(codePackage, config, callback, logger, lambda) {
     lambda = new AWS.Lambda({
       region: config.region,
       accessKeyId: "accessKeyId" in config ? config.accessKeyId : "",
-      secretAccessKey: "secretAccessKey" in config ? config.secretAccessKey : ""
+      secretAccessKey: "secretAccessKey" in config ? config.secretAccessKey : "",
+      sessionToken: "sessionToken" in config ? config.sessionToken : ""
     });
   }
 


### PR DESCRIPTION
Without the sessionToken there is no way to use an AccessKey and SecretAccessKey from the sts.assumeRole() call because it relies on having a session token. This is especially needed when using a parent aws account for IAM access and then assuming role into application application aws accounts through a trust relationship. 

I passing "" if sessionToken is not provided and it seems to work the same as the way the AccessKey and SecretAccessKey are working when not passed in. 

I have tested it with both the sessionToken and just letting the creds come from the config and both cases are working. IE the new feature is working and I dont believe I broke any previous features.