### PR TITLE
Add VPC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ module.exports = {
   functionName: <function name>,
   timeout: 10,
   memorySize: 128,
-  runtime: 'nodejs', // default: 'nodejs'
+  runtime: 'nodejs', // default: 'nodejs',
+  vpc: { // optional
+    SecurityGroupIds: [<security group id>, ...],
+    SubnetIds: [<subnet id>, ...]
+  },
   eventSource: {
     EventSourceArn: <event source such as kinesis ARN>,
     BatchSize: 200,

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ exports.deploy = function(codePackage, config, callback, logger, lambda) {
     Timeout: config.timeout,
     MemorySize: config.memorySize
   };
+  if (config.vpc) params.VpcConfig = config.vpc;
 
   var updateEventSource = function(eventSource, callback) {
     var params = extend({

--- a/test/all.js
+++ b/test/all.js
@@ -27,6 +27,10 @@ describe('node aws lambda module', function() {
     description: 'helloworld description',
     timeout: 10,
     memorySize: 128,
+    vpc: {
+      SecurityGroupIds: ['sg-xxxxxxx1', 'sg-xxxxxxx2'],
+      SubnetIds: ['subnet-xxxxxxxx']
+    },
     eventSource: {
       EventSourceArn: "arn:aws:kinesis:us-east-1:xxx:stream/KinesisStream-x0",
       BatchSize: 200,
@@ -79,7 +83,11 @@ describe('node aws lambda module', function() {
           Role: 'arn:aws:iam:xxxxxx:rol/lambda-exec-role',
           Timeout: 10,
           MemorySize: 128,
-          Runtime: "nodejs"
+          Runtime: "nodejs",
+          VpcConfig: {
+            SecurityGroupIds: ['sg-xxxxxxx1', 'sg-xxxxxxx2'],
+            SubnetIds: ['subnet-xxxxxxxx']
+          }
         });
         expect(data.Code.Content.toString()).to.equal(fs.readFileSync(packageV1).toString());
         service.listEventSourceMappings({FunctionName: 'helloworld', EventSourceArn: "arn:aws:kinesis:us-east-1:xxx:stream/KinesisStream-x0"}, callback);
@@ -104,6 +112,10 @@ describe('node aws lambda module', function() {
         var newConfig = extend({}, sampleConfig);
         newConfig.timeout = 20;
         newConfig.memorySize = 128;
+        newConfig.vpc = {
+          SecurityGroupIds: ['sg-xxxxxxx3'],
+          SubnetIds: ['subnet-xxxxxxx1','subnet-xxxxxxx2']
+        }
         newConfig.eventSource = {
           EventSourceArn: "arn:aws:kinesis:us-east-1:xxx:stream/KinesisStream-x0",
           BatchSize: 50,
@@ -125,7 +137,11 @@ describe('node aws lambda module', function() {
           Role: 'arn:aws:iam:xxxxxx:rol/lambda-exec-role',
           Timeout: 20,
           MemorySize: 128,
-          Runtime: "nodejs"
+          Runtime: "nodejs",
+          VpcConfig: {
+            SecurityGroupIds: ['sg-xxxxxxx3'],
+            SubnetIds: ['subnet-xxxxxxx1', 'subnet-xxxxxxx2']
+          }
         });
 
         expect(data.Code.Content.toString()).to.equal(fs.readFileSync(packageV2).toString());

--- a/test/fake-lambda-service.js
+++ b/test/fake-lambda-service.js
@@ -50,7 +50,7 @@ module.exports = function() {
     createFunction: function(params, callback) {
       validateParams(params,
                      ['FunctionName', 'Code', 'Handler', 'Role', 'Runtime'],
-                     ['Description', 'MemorySize', 'Timeout'], 'createFunction')
+                     ['Description', 'MemorySize', 'Timeout', 'VpcConfig'], 'createFunction')
 
       var name = params.FunctionName;
       var code = params.Code;
@@ -153,7 +153,7 @@ module.exports = function() {
     updateFunctionConfiguration: function(params, callback) {
       validateParams(params,
                      ['FunctionName'],
-                     ['Description', 'Handler', 'MemorySize', 'Role', 'Timeout'], 'updateFunctionConfiguration')
+                     ['Description', 'Handler', 'MemorySize', 'Role', 'Timeout', 'VpcConfig'], 'updateFunctionConfiguration')
 
       var fun = getFun(params.FunctionName);
       if(!fun) {


### PR DESCRIPTION
AWS Lambda is currently supported VPC,
so I add `vpc` field to _lambda-config.js_ as `VpcConfig` parameter of createFunction or updateFunction.
A `VpcConfig` has `SecurityGroupIds` and `SubnetIds` as sub-fields,
but it simply set an object without validating them following `eventSource` format.

It's working ok in my environment.
