### PR TITLE
Add Publish flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ module.exports = {
   functionName: <function name>,
   timeout: 10,
   memorySize: 128,
-  publish: true, // optional, default: false,
+  publish: true, // default: false,
   runtime: 'nodejs', // default: 'nodejs',
   vpc: { // optional
     SecurityGroupIds: [<security group id>, ...],

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ module.exports = {
   functionName: <function name>,
   timeout: 10,
   memorySize: 128,
+  publish: true, // optional, default: false,
   runtime: 'nodejs', // default: 'nodejs',
   vpc: { // optional
     SecurityGroupIds: [<security group id>, ...],

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ exports.deploy = function(codePackage, config, callback, logger, lambda) {
     Timeout: config.timeout,
     MemorySize: config.memorySize
   };
+  if (config.publish) params.Publish = config.publish;
   if (config.vpc) params.VpcConfig = config.vpc;
 
   var updateEventSource = function(eventSource, callback) {

--- a/index.js
+++ b/index.js
@@ -35,9 +35,9 @@ exports.deploy = function(codePackage, config, callback, logger, lambda) {
     Handler: config.handler,
     Role: config.role,
     Timeout: config.timeout,
-    MemorySize: config.memorySize
+    MemorySize: config.memorySize,
+    Publish: (config.publish === true)
   };
-  if (config.publish) params.Publish = config.publish;
   if (config.vpc) params.VpcConfig = config.vpc;
 
   var updateEventSource = function(eventSource, callback) {
@@ -106,13 +106,14 @@ exports.deploy = function(codePackage, config, callback, logger, lambda) {
         return callback('Error reading specified package "'+ codePackage + '"');
       }
 
-      lambda.updateFunctionCode({FunctionName: params.FunctionName, ZipFile: data}, function(err, data) {
+      lambda.updateFunctionCode({FunctionName: params.FunctionName, ZipFile: data, Publish: params.Publish}, function(err, data) {
         if (err) {
           var warning = 'Package upload failed. '
           warning += 'Check your iam:PassRole permissions.'
           logger(warning);
           callback(err)
         } else {
+          delete(params.Publish);
           lambda.updateFunctionConfiguration(params, function(err, data) {
             if (err) {
               var warning = 'Update function configuration failed. '

--- a/index.js
+++ b/index.js
@@ -35,10 +35,10 @@ exports.deploy = function(codePackage, config, callback, logger, lambda) {
     Handler: config.handler,
     Role: config.role,
     Timeout: config.timeout,
-    MemorySize: config.memorySize,
-    Publish: (config.publish === true)
+    MemorySize: config.memorySize
   };
   if (config.vpc) params.VpcConfig = config.vpc;
+  var isPublish = (config.publish === true);
 
   var updateEventSource = function(eventSource, callback) {
     var params = extend({
@@ -106,14 +106,13 @@ exports.deploy = function(codePackage, config, callback, logger, lambda) {
         return callback('Error reading specified package "'+ codePackage + '"');
       }
 
-      lambda.updateFunctionCode({FunctionName: params.FunctionName, ZipFile: data, Publish: params.Publish}, function(err, data) {
+      lambda.updateFunctionCode({FunctionName: params.FunctionName, ZipFile: data, Publish: isPublish}, function(err, data) {
         if (err) {
           var warning = 'Package upload failed. '
           warning += 'Check your iam:PassRole permissions.'
           logger(warning);
           callback(err)
         } else {
-          delete(params.Publish);
           lambda.updateFunctionConfiguration(params, function(err, data) {
             if (err) {
               var warning = 'Update function configuration failed. '
@@ -136,6 +135,7 @@ exports.deploy = function(codePackage, config, callback, logger, lambda) {
 
       params['Code'] = { ZipFile: data };
       params['Runtime'] = "runtime" in config ? config.runtime : "nodejs";
+      params['Publish'] = isPublish;
       lambda.createFunction(params, function(err, data) {
         if (err) {
           var warning = 'Create function failed. '

--- a/test/all.js
+++ b/test/all.js
@@ -49,6 +49,7 @@ describe('node aws lambda module', function() {
     description: 'helloworld description',
     timeout: 10,
     memorySize: 128,
+    publish: true,
     runtime: "python2.7",
     eventSource: {
       EventSourceArn: "arn:aws:kinesis:us-east-1:xxx:stream/KinesisStream-x0",
@@ -66,7 +67,7 @@ describe('node aws lambda module', function() {
     service = new FakeLambdaService();
   });
 
-  it('should create the function with code, configuration and event source mapping on fresh deployment', function(done){
+  it('should create the function with code, configuration and event source mapping on fresh deployment', function(done) {
     async.waterfall([
       function(callback) {
         deploy(packageV1, sampleConfig, callback);
@@ -114,7 +115,7 @@ describe('node aws lambda module', function() {
         var newConfig = extend({}, sampleConfig);
         newConfig.timeout = 20;
         newConfig.memorySize = 128;
-        newConfig.publish = true;
+        newConfig.publish = false;
         newConfig.vpc = {
           SecurityGroupIds: ['sg-xxxxxxx3'],
           SubnetIds: ['subnet-xxxxxxx1','subnet-xxxxxxx2']
@@ -140,7 +141,7 @@ describe('node aws lambda module', function() {
           Role: 'arn:aws:iam:xxxxxx:rol/lambda-exec-role',
           Timeout: 20,
           MemorySize: 128,
-          Publish: true,
+          Publish: false,
           Runtime: "nodejs",
           VpcConfig: {
             SecurityGroupIds: ['sg-xxxxxxx3'],
@@ -179,6 +180,7 @@ describe('node aws lambda module', function() {
           Timeout: 10,
           Runtime: "python2.7",
           MemorySize: 128,
+          Publish: true,
         });
         callback()
       }

--- a/test/all.js
+++ b/test/all.js
@@ -50,7 +50,6 @@ describe('node aws lambda module', function() {
     timeout: 10,
     memorySize: 128,
     runtime: "python2.7",
-    publish: true,
     eventSource: {
       EventSourceArn: "arn:aws:kinesis:us-east-1:xxx:stream/KinesisStream-x0",
       BatchSize: 200,
@@ -180,7 +179,7 @@ describe('node aws lambda module', function() {
           Timeout: 10,
           Runtime: "python2.7",
           MemorySize: 128,
-          Publish: true
+          Publish: false
         });
         callback()
       }

--- a/test/all.js
+++ b/test/all.js
@@ -27,6 +27,7 @@ describe('node aws lambda module', function() {
     description: 'helloworld description',
     timeout: 10,
     memorySize: 128,
+    publish: true,
     vpc: {
       SecurityGroupIds: ['sg-xxxxxxx1', 'sg-xxxxxxx2'],
       SubnetIds: ['subnet-xxxxxxxx']
@@ -83,6 +84,7 @@ describe('node aws lambda module', function() {
           Role: 'arn:aws:iam:xxxxxx:rol/lambda-exec-role',
           Timeout: 10,
           MemorySize: 128,
+          Publish: true,
           Runtime: "nodejs",
           VpcConfig: {
             SecurityGroupIds: ['sg-xxxxxxx1', 'sg-xxxxxxx2'],
@@ -112,6 +114,7 @@ describe('node aws lambda module', function() {
         var newConfig = extend({}, sampleConfig);
         newConfig.timeout = 20;
         newConfig.memorySize = 128;
+        newConfig.publish = true;
         newConfig.vpc = {
           SecurityGroupIds: ['sg-xxxxxxx3'],
           SubnetIds: ['subnet-xxxxxxx1','subnet-xxxxxxx2']
@@ -137,6 +140,7 @@ describe('node aws lambda module', function() {
           Role: 'arn:aws:iam:xxxxxx:rol/lambda-exec-role',
           Timeout: 20,
           MemorySize: 128,
+          Publish: true,
           Runtime: "nodejs",
           VpcConfig: {
             SecurityGroupIds: ['sg-xxxxxxx3'],

--- a/test/all.js
+++ b/test/all.js
@@ -49,8 +49,8 @@ describe('node aws lambda module', function() {
     description: 'helloworld description',
     timeout: 10,
     memorySize: 128,
-    publish: true,
     runtime: "python2.7",
+    publish: true,
     eventSource: {
       EventSourceArn: "arn:aws:kinesis:us-east-1:xxx:stream/KinesisStream-x0",
       BatchSize: 200,
@@ -180,7 +180,7 @@ describe('node aws lambda module', function() {
           Timeout: 10,
           Runtime: "python2.7",
           MemorySize: 128,
-          Publish: true,
+          Publish: true
         });
         callback()
       }

--- a/test/fake-lambda-service.js
+++ b/test/fake-lambda-service.js
@@ -26,9 +26,9 @@ module.exports = function() {
     return {statusCode: 404};
   }
 
-  function validateParams(params, manditoryFields, optionalFields, apiName) {
-    var allFields = manditoryFields.concat(optionalFields);
-    var mandis = manditoryFields.slice();
+  function validateParams(params, mandatoryFields, optionalFields, apiName) {
+    var allFields = mandatoryFields.concat(optionalFields);
+    var mandis = mandatoryFields.slice();
     Object.keys(params).forEach(function(key) {
       if(allFields.indexOf(key) === -1) {
         throw "Param key '" + key +  "' is not allowed for the given API " + apiName;
@@ -136,8 +136,8 @@ module.exports = function() {
     // http://docs.aws.amazon.com/lambda/latest/dg/API_UpdateFunctionCode.html
     updateFunctionCode: function(params, callback) {
       validateParams(params,
-                     ['FunctionName', 'ZipFile'],
-                     [], 'updateFunctionCode');
+                     ['FunctionName'],
+                     ['Publish', 'ZipFile'], 'updateFunctionCode');
 
       var fun = getFun(params.FunctionName);
       if(!fun) {
@@ -145,6 +145,7 @@ module.exports = function() {
         return;
       }
 
+      fun.config.Publish = params.Publish;
       fun.code.ZipFile = params.ZipFile;
       callback();
     },
@@ -153,7 +154,7 @@ module.exports = function() {
     updateFunctionConfiguration: function(params, callback) {
       validateParams(params,
                      ['FunctionName'],
-                     ['Description', 'Handler', 'MemorySize', 'Role', 'Timeout', 'Publish', 'VpcConfig'],
+                     ['Description', 'Handler', 'MemorySize', 'Role', 'Timeout', 'VpcConfig'],
                      'updateFunctionConfiguration')
 
       var fun = getFun(params.FunctionName);

--- a/test/fake-lambda-service.js
+++ b/test/fake-lambda-service.js
@@ -50,7 +50,7 @@ module.exports = function() {
     createFunction: function(params, callback) {
       validateParams(params,
                      ['FunctionName', 'Code', 'Handler', 'Role', 'Runtime'],
-                     ['Description', 'MemorySize', 'Timeout', 'VpcConfig'], 'createFunction')
+                     ['Description', 'MemorySize', 'Timeout', 'Publish', 'VpcConfig'], 'createFunction')
 
       var name = params.FunctionName;
       var code = params.Code;
@@ -153,7 +153,8 @@ module.exports = function() {
     updateFunctionConfiguration: function(params, callback) {
       validateParams(params,
                      ['FunctionName'],
-                     ['Description', 'Handler', 'MemorySize', 'Role', 'Timeout', 'VpcConfig'], 'updateFunctionConfiguration')
+                     ['Description', 'Handler', 'MemorySize', 'Role', 'Timeout', 'Publish', 'VpcConfig'],
+                     'updateFunctionConfiguration')
 
       var fun = getFun(params.FunctionName);
       if(!fun) {


### PR DESCRIPTION
AWS Lambda supports [versioning feature](https://aws.amazon.com/releasenotes/AWS-Lambda/6316007333823299) since 2015-10-08.
I added feature to pass Publish flag at deploy.

Current version works with default value "false".
I made it to be selectable at following API actions.

* [Create Function](http://docs.aws.amazon.com/ja_jp/lambda/latest/dg/API_CreateFunction.html)
* [Update Function](http://docs.aws.amazon.com/ja_jp/lambda/latest/dg/API_UpdateFunctionCode.html)

I tested it in my environment and works fine.