### PR TITLE
Added config.runtime as a param on deploy

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ exports.deploy = function(codePackage, config, callback, logger, lambda) {
     Handler: config.handler,
     Role: config.role,
     Timeout: config.timeout,
-    MemorySize: config.memorySize
+    MemorySize: config.memorySize,
+    Runtime: config.runtime
   };
   if (config.vpc) params.VpcConfig = config.vpc;
   var isPublish = (config.publish === true);

--- a/test/all.js
+++ b/test/all.js
@@ -28,6 +28,7 @@ describe('node aws lambda module', function() {
     timeout: 10,
     memorySize: 128,
     publish: true,
+    runtime: 'nodejs',
     vpc: {
       SecurityGroupIds: ['sg-xxxxxxx1', 'sg-xxxxxxx2'],
       SubnetIds: ['subnet-xxxxxxxx']

--- a/test/fake-lambda-service.js
+++ b/test/fake-lambda-service.js
@@ -154,7 +154,7 @@ module.exports = function() {
     updateFunctionConfiguration: function(params, callback) {
       validateParams(params,
                      ['FunctionName'],
-                     ['Description', 'Handler', 'MemorySize', 'Role', 'Timeout', 'VpcConfig'],
+                     ['Description', 'Handler', 'MemorySize', 'Role', 'Timeout', 'VpcConfig', 'Runtime'],
                      'updateFunctionConfiguration')
 
       var fun = getFun(params.FunctionName);


### PR DESCRIPTION
We ran into the problem where we couldn't update runtime environment to node 4.3 by config. These changes intend to fix that.
