### PR TITLE
Make default Runtime nodejs4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ module.exports = {
   timeout: 10,
   memorySize: 128,
   publish: true, // default: false,
-  runtime: 'nodejs', // default: 'nodejs',
+  runtime: 'nodejs4.3', // default: 'nodejs4.3',
   vpc: { // optional
     SecurityGroupIds: [<security group id>, ...],
     SubnetIds: [<subnet id>, ...]

--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ exports.deploy = function(codePackage, config, callback, logger, lambda) {
       }
 
       params['Code'] = { ZipFile: data };
-      params['Runtime'] = "runtime" in config ? config.runtime : "nodejs";
+      params['Runtime'] = "runtime" in config ? config.runtime : "nodejs4.3";
       params['Publish'] = isPublish;
       lambda.createFunction(params, function(err, data) {
         if (err) {

--- a/test/all.js
+++ b/test/all.js
@@ -85,7 +85,7 @@ describe('node aws lambda module', function() {
           Timeout: 10,
           MemorySize: 128,
           Publish: true,
-          Runtime: "nodejs",
+          Runtime: "nodejs4.3",
           VpcConfig: {
             SecurityGroupIds: ['sg-xxxxxxx1', 'sg-xxxxxxx2'],
             SubnetIds: ['subnet-xxxxxxxx']
@@ -141,7 +141,7 @@ describe('node aws lambda module', function() {
           Timeout: 20,
           MemorySize: 128,
           Publish: false,
-          Runtime: "nodejs",
+          Runtime: "nodejs4.3",
           VpcConfig: {
             SecurityGroupIds: ['sg-xxxxxxx3'],
             SubnetIds: ['subnet-xxxxxxx1', 'subnet-xxxxxxx2']


### PR DESCRIPTION
AWS explicitly recommends Lambda functions use nodejs4.3 so it makes sense for that to be the default value.