### PR TITLE
Workaround for bug in gulp-zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ gulp.task('node-mods', function() {
 });
 
 gulp.task('zip', function() {
-  return gulp.src(['dist/**/*', '!dist/package.json'])
+  return gulp.src(['dist/**/*', '!dist/package.json'], {nodir: true})
     .pipe(zip('dist.zip'))
     .pipe(gulp.dest('./'));
 });


### PR DESCRIPTION
There's a known issue with gulp-zip that means that failing to use the nodir: true parameter means that the zip file doesn't extract correctly once uploaded to AWS Lambda. The change ensures this works as expected. See the thread here: https://github.com/sindresorhus/gulp-zip/issues/64